### PR TITLE
Added jetty-maven-plugin to make it easy to start for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,17 @@
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>9.2.10.v20150310</version>
+				<configuration>
+			    <scanIntervalSeconds>10</scanIntervalSeconds>
+				    <webApp>
+				      	<contextPath>/</contextPath>
+				    </webApp>
+			  </configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<name>simple-web-app</name>


### PR DESCRIPTION
A great base, but the startup process was more painful for developing that it needed to be, so I just dropped in a Jetty plugin. Simply run `mvn jetty:run` and away you go. Feel free to ignore, but it might be useful. 