### PR TITLE
Fix "Timeout scanning annotations" error on jetty:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
 			    <scanIntervalSeconds>10</scanIntervalSeconds>
 				    <webApp>
 				      	<contextPath>/</contextPath>
+				      	<webInfIncludeJarPattern>.*/spring-[^/]*\.jar$</webInfIncludeJarPattern>
 				    </webApp>
 			  </configuration>
 			</plugin>


### PR DESCRIPTION
I'm getting a `java.lang.Exception: Timeout scanning annotations` when running `mvn jetty:run` and the web app fails to start. As suggested on [this thread](https://dev.eclipse.org/mhonarc/lists/jetty-users/msg07702.html]) on jetty-users list, the issue can be avoided by setting [webInfIncludeJarPattern](https://www.eclipse.org/jetty/documentation/9.3.x/configuring-webapps.html#web-inf-include-jar-pattern) parameter.

(pom.xml seems to have both tabs and spaces for indentation. I used the same white spaces as the line above, but I would suggest unifying the indentations if you have a certain convention and time to have a look at this.)