### PR TITLE
Fix annotation scan timeout. Change jetty:run context path and port t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,13 +169,23 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.10.v20150310</version>
-				<configuration>
-			    <scanIntervalSeconds>10</scanIntervalSeconds>
-				    <webApp>
-				      	<contextPath>/</contextPath>
-				    </webApp>
-			  </configuration>
+                <version>9.4.3.v20170317</version>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <name>jetty.http.port</name>
+                            <value>8081</value>
+                        </systemProperty>
+                        <systemProperty>
+                            <name>org.eclipse.jetty.annotations.maxWait</name>
+                            <value>320</value>
+                        </systemProperty>
+                    </systemProperties>
+                    <scanIntervalSeconds>10</scanIntervalSeconds>
+                    <webApp>
+                        <contextPath>/simple-web-app</contextPath>
+                    </webApp>
+                </configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -228,12 +228,12 @@
 				<property name="tokenEndpointAuthMethod" value="SECRET_BASIC" />
 				<property name="redirectUris">
 					<set>
-						<value>http://localhost:8080/simple-web-app/openid_connect_login</value>
+						<value>http://localhost:8081/simple-web-app/openid_connect_login</value>
 					</set>
 				</property>
 				<!-- for signed requests -->
 				<property name="requestObjectSigningAlg" value="RS256" />
-				<property name="jwksUri" value="http://localhost:8080/simple-web-app/jwk" />
+				<property name="jwksUri" value="http://localhost:8081/simple-web-app/jwk" />
 			</bean>
 		</property>
 		<!-- 
@@ -274,7 +274,7 @@
 						<property name="tokenEndpointAuthMethod" value="SECRET_BASIC" />
 						<property name="redirectUris">
 							<set>
-								<value>http://localhost:8080/simple-web-app/openid_connect_login</value>
+								<value>http://localhost:8081/simple-web-app/openid_connect_login</value>
 							</set>
 						</property>
 					</bean>
@@ -306,7 +306,7 @@
 						<property name="tokenEndpointAuthMethod" value="SECRET_BASIC" />
 						<property name="redirectUris">
 							<set>
-								<value>http://localhost:8080/simple-web-app/openid_connect_login</value>
+								<value>http://localhost:8081/simple-web-app/openid_connect_login</value>
 							</set>
 						</property>
 						
@@ -329,7 +329,7 @@
 				<property name="tokenEndpointAuthMethod" value="SECRET_BASIC" />
 				<property name="redirectUris">
 					<set>
-						<value>http://localhost:8080/simple-web-app/openid_connect_login</value>
+						<value>http://localhost:8081/simple-web-app/openid_connect_login</value>
 					</set>
 				</property>
 			</bean>


### PR DESCRIPTION
This PR changes the jetty:run context root and specifies port 8081 making it easy to run the simple-web-app on the same machine as openid-connect-server-webapp.

I also had problems with timeout while scanning annotations and this PR increase the timeout value. 